### PR TITLE
Feat/msca 758 exclude gamma

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "crosswalk"
-version = "0.0.1"
+version = "0.0.2"
 description = "A package for value alignment across sources"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     "matplotlib>=3.3.0",
     "threadpoolctl>=2.0.0",
     "pandas>=1.3.0",
-    "limetr<0.1.0",
+    "limetr>=0.0.8,<0.1.0",
     "seaborn>=0.11.0",
     "xspline==0.0.7",
 ]

--- a/src/crosswalk/model.py
+++ b/src/crosswalk/model.py
@@ -624,7 +624,7 @@ class CWModel:
             gamma = np.hstack((self.lt.gamma, np.full(self.num_vars - 1, np.nan)))
             re = np.hstack(
                 (
-                    self.lt.u,
+                    self.lt.estimate_re(),
                     np.full((self.cwdata.num_studies, self.num_vars - 1), np.nan),
                 )
             )

--- a/src/crosswalk/model.py
+++ b/src/crosswalk/model.py
@@ -655,6 +655,7 @@ class CWModel:
         study_id=None,
         data_id=None,
         ref_dorms=None,
+        include_gamma: bool = True,
     ):
         """Adjust alternative values.
 
@@ -676,6 +677,11 @@ class CWModel:
             ref_dorms (str, optional):
                 Name of the column with reference dorms, if is ``None``, use the
                 gold_dorm as the reference dorm. Default to ``None``.
+            include_gamma (bool, optional):
+                If ``True`` (default), propagate the between-study variance
+                ``gamma`` into the adjusted standard error. If ``False``, omit
+                it so the returned SE reflects only the original measurement SE
+                and the fixed-effect prediction uncertainty. Default to ``True``.
 
         Returns:
             pandas.DataFrame:
@@ -744,12 +750,15 @@ class CWModel:
                 ]
             )
         )
-        gamma = np.array(
-            [
-                self.gamma[0] if dorm != self.gold_dorm else 0.0
-                for dorm in df[orig_dorms]
-            ]
-        )
+        if include_gamma:
+            gamma = np.array(
+                [
+                    self.gamma[0] if dorm != self.gold_dorm else 0.0
+                    for dorm in df[orig_dorms]
+                ]
+            )
+        else:
+            gamma = np.zeros(df.shape[0])
 
         transformed_ref_vals_mean = (
             transformed_orig_vals_mean - pred_diff_mean - random_effects

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -109,6 +109,47 @@ def test_adjust_orig_vals(cwdata, cov_models, alt_dorm, ref_dorm):
     assert np.allclose(pred_df["data_id"], np.arange(pred_df.shape[0]))
 
 
+def test_adjust_orig_vals_include_gamma(cwdata, cov_models):
+    obs_type = "diff_log"
+    gold_dorm = "3"
+    alt_dorm = "2"
+    cwmodel = model.CWModel(
+        cwdata, obs_type, cov_models=cov_models, gold_dorm=gold_dorm
+    )
+    cwmodel.fit()
+    # Sanity check: a positive gamma is needed for the toggle to be observable.
+    assert cwmodel.gamma[0] > 0.0
+
+    new_df = pd.DataFrame(
+        {
+            "dorms": np.array([alt_dorm, gold_dorm] * (cwdata.num_obs // 2)),
+            "vals": np.ones(cwdata.num_obs),
+            "se": np.zeros(cwdata.num_obs),
+        }
+    )
+    for cov in cwdata.covs.columns:
+        new_df[cov] = np.ones(cwdata.num_obs)
+
+    kwargs = dict(
+        df=new_df, orig_dorms="dorms", orig_vals_mean="vals", orig_vals_se="se"
+    )
+    pred_with = cwmodel.adjust_orig_vals(**kwargs, include_gamma=True)
+    pred_without = cwmodel.adjust_orig_vals(**kwargs, include_gamma=False)
+
+    assert np.allclose(pred_with["ref_vals_mean"], pred_without["ref_vals_mean"])
+
+    gold_rows = new_df["dorms"].values == gold_dorm
+    alt_rows = ~gold_rows
+    assert np.allclose(
+        pred_with.loc[gold_rows, "ref_vals_sd"],
+        pred_without.loc[gold_rows, "ref_vals_sd"],
+    )
+    assert (
+        pred_with.loc[alt_rows, "ref_vals_sd"]
+        > pred_without.loc[alt_rows, "ref_vals_sd"]
+    ).all()
+
+
 @pytest.mark.parametrize("cov_name", ["cov0", "cov1"])
 @pytest.mark.parametrize("spline", [None, XSpline(np.linspace(-2.0, 2.0, 3), 3)])
 @pytest.mark.parametrize("soln_name", [None, "cov"])


### PR DESCRIPTION
## Summary

Add an `include_gamma` flag to `CWModel.adjust_orig_vals` that lets callers
choose whether the between-study variance term (`gamma`) is propagated into
the returned standard error. The default (`True`) preserves existing
behavior; passing `False` returns an SE that reflects only the original
measurement error and the fixed-effect prediction uncertainty.

This addresses [MSCA-758](https://jira.ihme.washington.edu/browse/MSCA-758),
where downstream consumers need an adjusted SE that excludes the
random-effect contribution.

This branch also brings the package up to date with `limetr` 0.0.8, whose
`LimeTr` object no longer exposes the cached `.u` random-effects attribute.

## What changed

- `src/crosswalk/model.py`
  - `adjust_orig_vals` — new `include_gamma: bool = True` keyword; when
    `False`, the per-row `gamma` vector is replaced by zeros so it drops out
    of `transformed_ref_vals_sd`. Docstring updated.
  - `create_result_df` — replace `self.lt.u` with `self.lt.estimate_re()`.
    `limetr` 0.0.8 removed the cached `.u` attribute and computes the random
    effects on demand instead; without this, `create_result_df` raises
    `AttributeError` for any random-intercept model.
- `pyproject.toml`
  - bump version `0.0.1` → `0.0.2` for the release that carries this work.
  - pin `limetr` to `>=0.0.8,<0.1.0` so the `estimate_re` API is guaranteed.
- `tests/test_model.py` — new `test_adjust_orig_vals_include_gamma` that
  fits a `CWModel`, calls `adjust_orig_vals` with both flag values on a
  frame mixing gold and non-gold dorms, and asserts:
  - `ref_vals_mean` is unchanged by the toggle,
  - SE is identical on gold-dorm rows (gamma is zero there in both
    branches),
  - SE is strictly larger with `include_gamma=True` on non-gold rows.
  Includes a `gamma[0] > 0` sanity check so the test fails informatively
  if a future fixture change makes the toggle unobservable.
